### PR TITLE
Check the presence of focus on the window reference

### DIFF
--- a/addon/components/share-button.js
+++ b/addon/components/share-button.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
     var newWindow = window.open(url, 'Facebook',
     'location=no,toolbar=no,menubar=no,scrollbars=no,status=no, width=600, height=600, top=' + popupPosition.top + ', left=' + popupPosition.left);
 
-    if (window.focus) {
+    if (newWindow.focus) {
       newWindow.focus();
     }
   }


### PR DESCRIPTION
Fixes an issue that popped up in my production logs where newWindow.focus was undefined