### PR TITLE
Make sure newWindow is not undefined

### DIFF
--- a/addon/components/share-button.js
+++ b/addon/components/share-button.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
     var newWindow = window.open(url, 'Facebook',
     'location=no,toolbar=no,menubar=no,scrollbars=no,status=no, width=600, height=600, top=' + popupPosition.top + ', left=' + popupPosition.left);
 
-    if (newWindow.focus) {
+    if (typeof(newWindow) != 'undefined' && newWindow.focus) {
       newWindow.focus();
     }
   }


### PR DESCRIPTION
Fixes an issue with window.open returning nil in browsers that do not
allow a new tab/window to be opened.

Facebook in-app browser or fullscreen web apps otherwise throw `TypeError: undefined is not an object (evaluating 'n.focus')` in production logs.