### PR TITLE
Remove outline styles for better accessibility

### DIFF
--- a/addon/styles/ember-social-share.css
+++ b/addon/styles/ember-social-share.css
@@ -1,6 +1,3 @@
-button:focus, button:active, button:visited {
-    outline: none;
-}
 .fb-share-button {
   background: #4267b2;
   border: 1px solid #4267b2;


### PR DESCRIPTION
Removed these focus styles, since this isn't something that can be reset to default in the user's CSS in a cross-browser compatible way, and the removal of focus styles hampers accessibility for keyboard navigation.