### PR TITLE
make sure newWindow is not null

### DIFF
--- a/addon/components/share-button.js
+++ b/addon/components/share-button.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
     var newWindow = window.open(url, 'Facebook',
     'location=no,toolbar=no,menubar=no,scrollbars=no,status=no, width=600, height=600, top=' + popupPosition.top + ', left=' + popupPosition.left);
 
-    if (typeof(newWindow) != 'undefined' && newWindow.focus) {
+    if (typeof(newWindow) !== 'undefined' && newWindow !== null && newWindow.focus) {
       newWindow.focus();
     }
   }


### PR DESCRIPTION
I receive bug reports in production from Facebook in-app browser