### PR TITLE
Email share button

### DIFF
--- a/addon/components/email-share-button.js
+++ b/addon/components/email-share-button.js
@@ -5,9 +5,7 @@ export default ShareButton.extend({
   layout,
   classNames: ['email-share-button', 'share-button'],
 
-  recipient: '',
-  subject: '',
   body: '',
-  title: ''
-
+  recipient: '',
+  subject: ''
 });

--- a/addon/components/email-share-button.js
+++ b/addon/components/email-share-button.js
@@ -1,0 +1,13 @@
+import ShareButton from '../components/share-button';
+import layout from '../templates/components/email-share-button';
+
+export default ShareButton.extend({
+  layout,
+  classNames: ['email-share-button', 'share-button'],
+
+  recipient: '',
+  subject: '',
+  body: '',
+  title: ''
+
+});

--- a/addon/components/fb-share-button.js
+++ b/addon/components/fb-share-button.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import ShareButton from '../components/share-button';
 import layout from '../templates/components/fb-share-button';
 

--- a/addon/components/share-panel.js
+++ b/addon/components/share-panel.js
@@ -10,7 +10,9 @@ export default Ember.Component.extend({
                       'vkontakte': 'vk-share-button',
                       'twitter': 'twitter-share-button',
                       'linkedin': 'linkedin-share-button',
-                      'gplus': 'gplus-share-button'
+                      'gplus': 'gplus-share-button',
+                      'email': 'email-share-button',
+                      'e-mail': 'email-share-button',
                   },
   buttons: '',
   labels: '',

--- a/addon/styles/ember-social-share.css
+++ b/addon/styles/ember-social-share.css
@@ -38,6 +38,7 @@
   -o-transition: opacity .25s ease-in-out;
 }
 
+.email-div,
 .linkedin-div,
 .fb-div,
 .twitter-div,
@@ -79,6 +80,17 @@
 .twitter-share-button {
   background-color: #1b95e0;
   border: 1px solid #1b95e0;
+}
+
+.email-share-button {
+  background-color: #666666;
+  border: 1px solid #666666;
+}
+
+.email-share-button span,
+.email-share-button a {
+  color: white;
+  text-decoration: none;
 }
 
 .share-panel {

--- a/addon/styles/ember-social-share.css
+++ b/addon/styles/ember-social-share.css
@@ -85,12 +85,16 @@
 .email-share-button {
   background-color: #666666;
   border: 1px solid #666666;
+  top: 0;
 }
 
-.email-share-button span,
 .email-share-button a {
-  color: white;
   text-decoration: none;
+  color: white;
+}
+
+.email-share-button svg {
+  padding: 0 0 0 4px;
 }
 
 .share-panel {

--- a/addon/templates/components/email-share-button.hbs
+++ b/addon/templates/components/email-share-button.hbs
@@ -1,0 +1,5 @@
+<a href="mailto:{{recipient}}?subject={{subject}}&amp;body={{body}}"
+   title="{{title}}">
+   {{fa-icon 'envelope' size='lg'}}
+   <span>{{yield}}</span>
+</a>

--- a/addon/templates/components/email-share-button.hbs
+++ b/addon/templates/components/email-share-button.hbs
@@ -1,5 +1,4 @@
-<a href="mailto:{{recipient}}?subject={{subject}}&amp;body={{body}}"
-   title="{{title}}">
+<a href="mailto:{{recipient}}?subject={{subject}}&amp;body={{body}}">
    {{fa-icon 'envelope' size='lg'}}
    <span>{{yield}}</span>
 </a>

--- a/addon/templates/components/share-panel.hbs
+++ b/addon/templates/components/share-panel.hbs
@@ -1,3 +1,3 @@
 {{#each components as |button|}}
-  {{#component button.name adaptive=adaptive url=url image=image title=title text=text hashtags=hashtags quote=quote via=via}}{{button.label}}{{/component}}
+  {{#component button.name adaptive=adaptive url=url image=image title=title text=text hashtags=hashtags quote=quote via=via recipient=recipient subject=subject body=body}}{{button.label}}{{/component}}
 {{/each}}

--- a/app/components/email-share-button.js
+++ b/app/components/email-share-button.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-social-share/components/email-share-button';

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "buttons"
   ],
   "dependencies": {
+    "@fortawesome/ember-fontawesome": "^0.1.0-8",
+    "@fortawesome/free-brands-svg-icons": "^5.1.0-11",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@fortawesome/ember-fontawesome": "0.1.0-8",
     "@fortawesome/free-brands-svg-icons": "^5.1.0-11",
+    "@fortawesome/free-solid-svg-icons": "^5.1.0-11",
     "broccoli-asset-rev": "^2.6.0",
     "ember-cli": "^2.18.0",
     "ember-cli-app-version": "^3.1.0",
@@ -51,10 +52,9 @@
   "dependencies": {
     "@fortawesome/ember-fontawesome": "^0.1.0-8",
     "@fortawesome/free-brands-svg-icons": "^5.1.0-11",
+    "@fortawesome/free-solid-svg-icons": "^5.1.0-11",
     "ember-cli-babel": "^6.8.2",
-    "ember-cli-htmlbars": "^2.0.3",
-    "@fortawesome/ember-fontawesome": "^0.1.0-8",
-    "@fortawesome/free-brands-svg-icons": "^5.1.0-11"
+    "ember-cli-htmlbars": "^2.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,7 @@
 
 <h3>Separated buttons with adaptive design and non-default url (example.com)</h3>
 
+{{#email-share-button recipient="test@gmail.com" subject="Here is a test subject" body="this is only a test email" title="Share via e-mail"}}Share via e-mail{{/email-share-button}}
 {{#fb-share-button quote="Here is an excerpt from the source" url="http://example.com" title="Test title 2" image="http://www.mignews.ru/aimages/05_16/180516_122302_84352_2.jpg" }}Share on Facebook{{/fb-share-button}}
 {{#vk-share-button url="http://example.com" title="Test title 1" image="http://www.mignews.ru/aimages/05_16/180516_122302_84352_2.jpg" text="qwerty" }}Share{{/vk-share-button}}
 {{#twitter-share-button url="http://example.com" title="Test tweet" hashtags="example,test" via="example.org"}}Tweet{{/twitter-share-button}}
@@ -9,8 +10,8 @@
 {{#gplus-share-button url="http://example.com"}}Share{{/gplus-share-button}}
 
 <h3>Share panel without adaptive design with default url</h3>
-{{share-panel adaptive=false buttons="facebook, vk, twitter, linkedin, gplus" labels="Share,Share,Tweet,Share,Share" title="Title!" quote="Here is an excerpt from the source" image="http://www.vokrugsveta.ru/img/cmn/2013/06/15/002.jpg" text="Ember social share addon" hashtags="embersocialshare,ember" url="https://www.npmjs.com/package/ember-social-share"}}
- {{outlet}}
+{{share-panel adaptive=false buttons="email, facebook, vk, twitter, linkedin, gplus" labels="Email,Share,Share,Tweet,Share,Share" title="Title!" quote="Here is an excerpt from the source" image="http://www.vokrugsveta.ru/img/cmn/2013/06/15/002.jpg" text="Ember social share addon" hashtags="embersocialshare,ember" url="https://www.npmjs.com/package/ember-social-share" recipient="test@gmail.com" subject="No adaptive design" body="this is only a test email without adaptive design"}}
 
-<h3>Share panel in a different order with different labels (Twitter, Linkedin, VK, Facebook, Google Plus)</h3>
-{{share-panel adaptive=false buttons="twitter, linkedin, vk, facebook, gplus" labels="Tweet,Share on Linkedin,Share,Share to Facebook,Share with circles on Google Plus" title="Title!" quote="Here is an excerpt from the source" image="http://www.vokrugsveta.ru/img/cmn/2013/06/15/002.jpg" text="Ember social share addon" hashtags="embersocialshare,ember" url="https://www.npmjs.com/package/ember-social-share"}}
+
+<h3>Share panel in a different order with different labels (Twitter, Linkedin, VK, Facebook, Email, Google Plus)</h3>
+{{share-panel adaptive=false buttons="twitter, linkedin, vk, facebook, email, gplus" labels="Tweet,Share on Linkedin,Share,Share to Facebook,Email to friends,Share with circles on Google Plus" title="Title!" quote="Here is an excerpt from the source" image="http://www.vokrugsveta.ru/img/cmn/2013/06/15/002.jpg" text="Ember social share addon" hashtags="embersocialshare,ember" url="https://www.npmjs.com/package/ember-social-share" recipient="test@test.com" subject="Here is a test subject for reordered buttons" body="Reorder your buttons!"}}

--- a/tests/integration/components/email-share-button-test.js
+++ b/tests/integration/components/email-share-button-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('email-share-button', 'Integration | Component | email share button', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{email-share-button}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#email-share-button}}
+      template block text
+    {{/email-share-button}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
This PR adds a `Share via e-mail` button. It allows the developer to pass in whatever `body`, `subject`, `title`, and `recipient` they want. If none are provided, the default e-mail client for that person's computer will open to a blank e-mail.

There is an issue where the button doesn't align properly with the other buttons in the dummy app, so any help would be greatly appreciated @Crabar!